### PR TITLE
extract source text fixes

### DIFF
--- a/Utils.py
+++ b/Utils.py
@@ -5,7 +5,7 @@
 #   SIL International
 #   7/23/2014
 #
-#   Version 3.3 - 1/27/22 - Ron Lockwood
+#   Version 3.3.1 - 1/27/22 - Ron Lockwood
 #    Fixed index error bug when an index to the sense list overflowed. This is in
 #    The TextWord class. Also prevent empty lexical units from being produced when
 #    no root is present. This fixes #39 & #40.


### PR DESCRIPTION
Fixed index error bug when an index to the sense list overflowed. This is in the TextWord class. Also prevent empty lexical units from being produced when no root is present. This fixes #39 & #40.