### PR TITLE
Fixes #90 Ignore duplicate glosses

### DIFF
--- a/CatalogTargetPrefixes.py
+++ b/CatalogTargetPrefixes.py
@@ -5,6 +5,10 @@
 #   University of Washington, SIL International
 #   12/5/14
 #
+#   Version 3.5.5 - 8/8/22 - Ron Lockwood
+#   Fixes #90 Ignore duplicate glosses As long as they are affixes in the same 
+#   entry with the same morphtype. E.g. 3 suffixes named pl.
+#
 #   Version 3.5.4 - 8/8/22 - Ron Lockwood
 #    Error message fix.
 #
@@ -232,6 +236,8 @@ def catalog_affixes(DB, configMap, filePath, report=None, useCacheIfAvailable=Fa
             # Process affixes or clitics (stems that aren't in the morphNames list)
             if processIt:
             
+                localMap = {}
+                
                 # Loop through senses
                 for i, mySense in enumerate(e.SensesOS):
                     
@@ -240,9 +246,13 @@ def catalog_affixes(DB, configMap, filePath, report=None, useCacheIfAvailable=Fa
                     # Convert dots to underscores in the affix gloss
                     myGloss = Utils.underscores(ITsString(mySense.Gloss.BestAnalysisAlternative).Text)
                     
-                    # Save the gloss and morph type
-                    glossAndTypeList.append((morphType, myGloss))
-                    
+                    # Don't add to the list if it's a duplicate. Same gloss and same morph type will just make duplicate entries in the affix dictionary.
+                    # If we add each of them, the user will get an error for having duplicates, but within an entry it doesn't matter.
+                    if (morphType, myGloss) not in localMap:
+                        
+                        # Save the gloss and morph type
+                        glossAndTypeList.append((morphType, myGloss))
+                        localMap[(morphType, myGloss)] = 1
     seen = set()
     
     TargetDB.CloseProject()


### PR DESCRIPTION
As long as they are affixes in the same entry with the same morphtype. E.g. 3 suffixes named pl.