### PR TITLE
report bug in do_replacements

### DIFF
--- a/ExtractBilingualLexicon.py
+++ b/ExtractBilingualLexicon.py
@@ -5,6 +5,10 @@
 #   University of Washington, SIL International
 #   12/4/14
 #
+#   Version 3.7.3 - 1/18/23 - Ron Lockwood
+#    Fixed bug where report was None in the do_replacements function and a warning was
+#    attempted to be outputted. Have LinkSenseTool call extract_bilingual_lex with a report object.
+#
 #   Version 3.7.2 - 1/7/23 - Ron Lockwood
 #    Fixes #214. Give a warning for replacement file entries that couldn't be
 #    found in the bilingual lexicon.
@@ -224,7 +228,7 @@ REPLDICTIONARY = 'repldictionary'
 # Documentation that the user sees:
 
 docs = {FTM_Name       : "Extract Bilingual Lexicon",
-        FTM_Version    : "3.7.2",
+        FTM_Version    : "3.7.3",
         FTM_ModifiesDB : False,
         FTM_Synopsis   : "Creates an Apertium-style bilingual lexicon.",               
         FTM_Help   : "",
@@ -451,7 +455,9 @@ def processReplacementEntries(biling_section, replMap, newDocType, replFile, rep
         # Ignore the default entry that gets installed
         if key != 'SourceWord1.1':
         
-            report.Warning(f'The replacement file entry {key} was not found in the bilingual lexicon.')
+            if report: # could be None
+            
+                report.Warning(f'The replacement file entry {key} was not found in the bilingual lexicon.')
         
     return new_biling_section
     

--- a/LinkSenseTool.py
+++ b/LinkSenseTool.py
@@ -5,6 +5,10 @@
 #   SIL International
 #   7/18/15
 #
+#   Version 3.7.7 - 1/18/23 - Ron Lockwood
+#    Fixed bug where report was None in the do_replacements function and a warning was
+#    attempted to be outputted. Have LinkSenseTool call extract_bilingual_lex with a report object.
+#
 #   Version 3.7.6 - 12/25/22 - Ron Lockwood
 #    Added RegexFlag before re constants
 #
@@ -180,7 +184,7 @@ from Linker import Ui_MainWindow
 # Documentation that the user sees:
 
 docs = {FTM_Name       : "Sense Linker Tool",
-        FTM_Version    : "3.7.6",
+        FTM_Version    : "3.7.7",
         FTM_ModifiesDB : True,
         FTM_Synopsis   : "Link source and target senses.",
         FTM_Help   : "",
@@ -1412,8 +1416,8 @@ def MainFunction(DB, report, modify=False):
         
     if retVal == REBUILD_BILING:
         
-        # Extract the bilingual lexicon        
-        error_list = ExtractBilingualLexicon.extract_bilingual_lex(DB, configMap)
+        # Extract the bilingual lexicon. Force a complete rebuild instead of using the cache.        
+        error_list = ExtractBilingualLexicon.extract_bilingual_lex(DB, configMap, report, useCacheIfAvailable=False)
         
         # output info, warnings, errors
         for msg in error_list:


### PR DESCRIPTION
Fixed bug where report was None in the do_replacements function and a warning was attempted to be outputted. Have LinkSenseTool call extract_bilingual_lex with a report object.