### PR TITLE
Fixes #1239.

### DIFF
--- a/Dev/Lib/TextInOutUtils.py
+++ b/Dev/Lib/TextInOutUtils.py
@@ -5,6 +5,10 @@
 #   SIL International
 #   7/1/24
 #
+#   Version 3.15 - 2/11/26 - Ron Lockwood
+#    Fixes #1239. When writing, don't check for a positive number of selected work projects.
+#    Zero is ok because we will always have the default project.
+#
 #   Version 3.14.2 - 12/13/25 - Ron Lockwood
 #   Fixes #1157 Use resizeable window and widgets.
 #
@@ -1428,17 +1432,15 @@ class TextInOutRulesWindow(QMainWindow):
         except:
             self.report.Error(_translate("TextInOutUtils", "Error saving settings."))
 
-        if len(self.selectedWorkProjects) > 0:
+        for i in range(len(self.selectedWorkProjects)+1): # +1 for the default project
 
-            for i in range(len(self.selectedWorkProjects)+1): # +1 for the default project
+            # Get all the wildebeest info. and save it in the element tree
+            self.saveWBinfo(self.xmlRootList[i])
 
-                # Get all the wildebeest info. and save it in the element tree
-                self.saveWBinfo(self.xmlRootList[i])
+            # Indent the xml to make it pretty then write it to a file.
+            ET.indent(self.xmlTreeList[i])
+            self.xmlTreeList[i].write(self.filePathList[i], encoding='utf-8', xml_declaration=True)
 
-                # Indent the xml to make it pretty then write it to a file.
-                ET.indent(self.xmlTreeList[i])
-                self.xmlTreeList[i].write(self.filePathList[i], encoding='utf-8', xml_declaration=True)
-
-                # We are done after the 0th project, if it is the default project so break out of the loop
-                if len(self.clusterProjects) == 0:
-                    break
+            # We are done after the 0th project, if it is the default project so break out of the loop
+            if len(self.clusterProjects) == 0:
+                break


### PR DESCRIPTION
When writing, don't check for a positive number of selected work projects. Zero is ok because we will always have the default project.