### PR TITLE
Regular expression syntax fixes

### DIFF
--- a/Dev/Modules/ConvertTextToSTAMPformat.py
+++ b/Dev/Modules/ConvertTextToSTAMPformat.py
@@ -5,6 +5,9 @@
 #   University of Washington, SIL International
 #   12/5/14
 #
+#   Version 3.15.3 - 3/10/26 - Ron Lockwood
+#    Regular expression syntax fixes that showed up with Python 3.13.
+#
 #   Version 3.15.2 - 3/6/26 - Ron Lockwood
 #    Upgraded to PyQt6 and Python 3.13.
 #
@@ -152,7 +155,7 @@ librariesToTranslate = ['ReadConfig', 'Utils', 'Mixpanel']
 # Documentation that the user sees:
 
 docs = {FTM_Name       : _translate("ConvertTextToSTAMPformat", "Convert Text to Synthesizer Format"),
-        FTM_Version    : "3.15.2",
+        FTM_Version    : "3.15.3",
         FTM_ModifiesDB : False,
         FTM_Synopsis   : _translate("ConvertTextToSTAMPformat", "Convert the file produced by {runApert} into a text file in a Synthesizer format").format(runApert=RunApertDocs[FTM_Name]),
         FTM_Help  : "", 
@@ -675,7 +678,7 @@ class ConversionData():
                 spec = IFsClosedValue(spec)
                 featGrpName = Utils.as_string(spec.FeatureRA.Name)
                 abbValue = Utils.as_string(spec.ValueRA.Abbreviation)
-                abbValue = re.sub('\.', '_', abbValue)
+                abbValue = re.sub(r'\.', '_', abbValue)
                 featAbbrevList.append((featGrpName, abbValue))
         return
     
@@ -1130,7 +1133,7 @@ def convertIt(pfxName, outName, report, sentPunct):
     
     for line in fAfx:
         
-        (affix, morphType) = re.split('\|', line.rstrip())
+        (affix, morphType) = re.split(r'\|', line.rstrip())
         affixMap[affix] = morphType
         
     fAfx.close()

--- a/Dev/Modules/LinkAllSensesAsDup.py
+++ b/Dev/Modules/LinkAllSensesAsDup.py
@@ -6,6 +6,9 @@
 #   7/24/23
 #
 #
+#   Version 3.15.2 - 3/10/26 - Ron Lockwood
+#    Regular expression syntax fixes that showed up with Python 3.13.
+#
 #   Version 3.15.1 - 3/6/26 - Ron Lockwood
 #    Upgraded to PyQt6 and Python 3.13.
 #
@@ -75,7 +78,7 @@ librariesToTranslate = ['ReadConfig', 'Utils', 'Mixpanel']
 #----------------------------------------------------------------
 # Documentation that the user sees:
 docs = {FTM_Name       : _translate("LinkAllSensesAsDup", "Link All Senses As Duplicate"),
-        FTM_Version    : "3.15.1",
+        FTM_Version    : "3.15.2",
         FTM_ModifiesDB : True,
         FTM_Synopsis   : _translate("LinkAllSensesAsDup", "Link all senses to the same ID in the target."),
         FTM_Help       : "",
@@ -143,7 +146,7 @@ def MainFunction(DB, report, modify=False):
     myStyle = Utils.getHyperLinkStyle(DB)
 
     preGuidStr = 'silfw://localhost/link?database%3d'
-    preGuidStr += re.sub('\s','+', targetProj)
+    preGuidStr += re.sub(r'\s','+', targetProj)
     preGuidStr += '%26tool%3dlexiconEdit%26guid%3d'
 
     # Loop through all the source entries

--- a/Dev/Modules/ViewSrcTgt.py
+++ b/Dev/Modules/ViewSrcTgt.py
@@ -5,6 +5,9 @@
 #   SIL International
 #   12/28/17
 #
+#   Version 3.15.2 - 3/10/26 - Ron Lockwood
+#    Regular expression syntax fixes that showed up with Python 3.13.
+#
 #   Version 3.15.1 - 3/6/26 - Ron Lockwood
 #    Upgraded to PyQt6 and Python 3.13.
 #
@@ -93,7 +96,7 @@ librariesToTranslate = ['ReadConfig', 'Utils', 'Mixpanel', 'SrcTgtViewer']
 #----------------------------------------------------------------
 # Documentation that the user sees:
 docs = {FTM_Name       : _translate("ViewSrcTgt", "View Source/Target Apertium Text Tool"),
-        FTM_Version    : "3.15.1",
+        FTM_Version    : "3.15.2",
         FTM_ModifiesDB : False,
         FTM_Synopsis   : _translate("ViewSrcTgt", "View an easy-to-read source or target text file."),
         FTM_Help       : "",
@@ -290,7 +293,7 @@ class Main(QMainWindow):
                 # parse the lexical units. This will give us tokens before, between 
                 # and after each lu. E.g. ^hi1.1<n>$, ^there2.3<dem><pl>$ gives
                 #                         ['', 'hi1.1<n>', ', ', 'there2.3<dem><pl>', '']
-                tokens = re.split('\^|\$', line)
+                tokens = re.split(r'\^|\$', line)
                 
                 # process pairs of tokens (punctuation and lexical unit)
                 for i in range(0,len(tokens)-1,2):


### PR DESCRIPTION
showed up with Python 3.13