### PR TITLE
Fixes #1273. Handle non-ASCII characters in paths

### DIFF
--- a/Dev/Lib/Utils.py
+++ b/Dev/Lib/Utils.py
@@ -5,6 +5,10 @@
 #   SIL International
 #   7/23/2014
 #
+#   Version 3.15.2 - 3/12/26 - Ron Lockwood
+#    Fixes #1273. Handle non-ASCII characters in paths when creating the batch file to run the makefile. 
+#    Use the Windows short path to avoid encoding issues with non-ASCII characters in the batch file.
+#
 #   Version 3.15.1 - 3/6/26 - Ron Lockwood
 #    Upgraded to PyQt6 and Python 3.13.
 #
@@ -199,6 +203,7 @@ import tempfile
 import os
 import unicodedata
 import itertools
+import ctypes
 from collections import defaultdict
 
 from PyQt6.QtCore import QCoreApplication, QTranslator, QLibraryInfo, QLocale
@@ -1403,3 +1408,21 @@ def getInterfaceLangCode():
         return FTConfig.UILanguage 
     else:
         return langOverride
+
+def get_short_path(long_path):
+    """Convert a long Windows path with non-ASCII chars to its short 8.3 equivalent."""
+    buf = ctypes.create_unicode_buffer(512)
+    ctypes.windll.kernel32.GetShortPathNameW(long_path, buf, 512)
+    return buf.value or long_path  # fall back to original if short path unavailable
+
+def get_long_path(short_path):
+    buf = ctypes.create_unicode_buffer(512)
+    ctypes.windll.kernel32.GetLongPathNameW(short_path, buf, 512)
+    return buf.value or short_path
+
+def get_short_dir_only_path(full_path):
+    """Convert a long Windows path with non-ASCII chars to its short 8.3 equivalent, but only for the directory part, not the file name."""
+    dir_path = os.path.dirname(full_path)
+    file_name = os.path.basename(full_path)
+    short_dir = get_short_path(dir_path)
+    return os.path.join(short_dir, file_name)

--- a/Dev/Modules/DoStampSynthesis.py
+++ b/Dev/Modules/DoStampSynthesis.py
@@ -5,6 +5,10 @@
 #   University of Washington, SIL International
 #   12/5/14
 #
+#   Version 3.15.3 - 3/12/26 - Ron Lockwood
+#    Fixes #1273. Handle non-ASCII characters in paths when creating the batch file to run the makefile. 
+#    Use the Windows short path to avoid encoding issues with non-ASCII characters in the batch file.
+#
 #   Version 3.15.2 - 3/6/26 - Ron Lockwood
 #    Upgraded to PyQt6 and Python 3.13.
 #
@@ -123,7 +127,7 @@
 
 import os
 import re 
-from subprocess import call
+import subprocess
 from datetime import datetime
 import winreg
 import xml.etree.ElementTree as ET
@@ -185,7 +189,7 @@ This is typically called target_text-syn.txt and is usually in the Output folder
 NOTE: Messages will say the source project is being used. Actually the target project is being used.""")
 
 docs = {FTM_Name       : _translate("DoStampSynthesis", "Synthesize Text with STAMP"),
-        FTM_Version    : "3.15.2",
+        FTM_Version    : "3.15.3",
         FTM_ModifiesDB : False,
         FTM_Synopsis   : _translate("DoStampSynthesis", "Synthesizes the target text with the tool STAMP."),
         FTM_Help       : "",
@@ -1356,7 +1360,6 @@ def synthesize(configMap, anaFile, synFile, report=None, overrideClean=False):
     global reqFeaturesMap
     stemNameList = []
     reqFeaturesMap = {}
-    globalXAmplePropMap = {}
 
     targetProject = ReadConfig.getConfigVal(configMap, ReadConfig.TARGET_PROJECT, report)
     clean = ReadConfig.getConfigVal(configMap, ReadConfig.CLEANUP_UNKNOWN_WORDS, report)
@@ -1384,16 +1387,27 @@ def synthesize(configMap, anaFile, synFile, report=None, overrideClean=False):
         error_list.append((_translate("DoStampSynthesis", "Lexicon files folder: {folder} does not exist.").format(folder=ReadConfig.TARGET_LEXICON_FILES_FOLDER), 2))
         return error_list
 
-    # Have all files start with targetProject
-    partPath = os.path.join(lexFolder, targetProject)
+    # Have all files start with targetProject.
+    # Use the short path for the lexicon files folder in case we have a path with non-ASCII characters that will cause problems for STAMP.
+    partPath = os.path.join(Utils.get_short_path(lexFolder), targetProject)
     
     # Create other files we need for STAMP
     cmdFileName = create_synthesis_files(partPath)
 
-    # run STAMP to synthesize the results. E.g. stamp32" -f ggg-Thesis_ctrl_files. txt -i ppp_verbs.ana -o ppp_verbs.syn
-    # this assumes stamp32.exe is in the current working directory.
+    # run STAMP to synthesize the results. E.g. stamp64" -f ggg-Thesis_ctrl_files. txt -i ppp_verbs.ana -o ppp_verbs.syn
+    try:
+        result = subprocess.run([FTPaths.STAMP_EXE, '-f', cmdFileName, '-i', Utils.get_short_dir_only_path(anaFile), '-o', Utils.get_short_dir_only_path(synFile)], capture_output=False)
+
+        if result.returncode != 0:
+                
+            error_list.append((_translate("DoStampSynthesis", "An error happened when running the STAMP tool."), 2))
+            error_list.append((result.stderr.decode(), 2))
+            return error_list
     
-    call([FTPaths.STAMP_EXE, '-f', cmdFileName, '-i', anaFile, '-o', synFile])
+    except subprocess.CalledProcessError as e:
+        error_list.append((_translate("DoStampSynthesis", "An error happened when running the STAMP tool."), 2))
+        error_list.append((e.stderr.decode(), 2))
+        return error_list
 
     # Replace underscores with spaces in the Synthesized file
     # Underscores were added for multiword entries that contained a space

--- a/Dev/Modules/RunApertium.py
+++ b/Dev/Modules/RunApertium.py
@@ -5,6 +5,10 @@
 #   SIL International
 #   1/1/17
 #
+#   Version 3.15.2 - 3/12/26 - Ron Lockwood
+#    Fixes #1273. Handle non-ASCII characters in paths when creating the batch file to run the makefile. 
+#    Use the Windows short path to avoid encoding issues with non-ASCII characters in the batch file.
+#
 #   Version 3.15.1 - 3/6/26 - Ron Lockwood
 #    Upgraded to PyQt6 and Python 3.13.
 #
@@ -102,7 +106,7 @@ The results of this module are found in the file you specified in the Target Tra
 This is typically called target_text-aper.txt and is usually in the Build folder.""")
 
 docs = {FTM_Name       : _translate("RunApertium", "Run Apertium"),
-        FTM_Version    : "3.15.1",
+        FTM_Version    : "3.15.2",
         FTM_ModifiesDB : False,
         FTM_Synopsis   : _translate("RunApertium", "Run the Apertium transfer engine."),
         FTM_Help       : "",  
@@ -372,7 +376,10 @@ def run_makefile(absPathToBuildFolder, report):
     # Create the batch file which merely cds to the appropriate
     # directory and runs make.
     fullPathMake = os.path.join(absPathToBuildFolder, DO_MAKE_SCRIPT_FILE)
-    f = open(fullPathMake, 'w', encoding='utf-8')
+
+    # 'mbcs' is a Python alias for the Windows system default ANSI codepage.
+    # Using 'mbcs' allows the batch file to be created with the correct encoding for the system, which is important if there are non-ASCII characters in the paths.
+    f = open(fullPathMake, 'w', encoding='mbcs')
 
     # make a variable for where the bilingual dictionary file should be found
     outStr = f'set {MAKEFILE_DICT_VARIABLE}={dictionaryPath}\n'
@@ -394,21 +401,22 @@ def run_makefile(absPathToBuildFolder, report):
     # set path to nothing
     outStr += f'set PATH=""\n'
 
+    short_build_path = Utils.get_short_path(absPathToBuildFolder)
+
     # Extract drive letter and switch to it if the path is on a different drive
-    drive_letter = os.path.splitdrive(absPathToBuildFolder)[0]
+    drive_letter = os.path.splitdrive(short_build_path)[0]
+
     if drive_letter:
+
         outStr += f'{drive_letter}\n'
 
-    # Put quotes around the path in case there's a space
-    outStr += f'cd "{absPathToBuildFolder}"\n'
-
-    outStr += f'"{FTPaths.MAKE_EXE}" 2>"{APERTIUM_ERROR_FILE}"\n'
-
+     # Put quotes around the paths in case there's a space
+    outStr += f'cd "{short_build_path}"\n'
+    outStr += f'"{Utils.get_short_path(FTPaths.MAKE_EXE)}" 2>"{APERTIUM_ERROR_FILE}"\n'
     f.write(outStr)
     f.close()
 
     retVal = subprocess.call([fullPathMake])
-
     return retVal
 
 def runApertium(DB, configMap, report):


### PR DESCRIPTION
Also use subprocess instead of call for stamp64.exe